### PR TITLE
Improve templates for initializing uninitialized memory (includes sanitizer parsing fixes).

### DIFF
--- a/src/repairchain/models/sanitizer_report.py
+++ b/src/repairchain/models/sanitizer_report.py
@@ -379,7 +379,7 @@ def parse_java_stack_trace(line: str) -> StackFrame:
     try:
         lineno_int = int(lineno.strip()) if lineno is not None else None
     except ValueError:
-        lineno = None
+        lineno_int = None
 
     funcname = funcname.strip() if funcname is not None else None
     filename = filename.strip() if filename is not None else None

--- a/src/repairchain/models/sanitizer_report.py
+++ b/src/repairchain/models/sanitizer_report.py
@@ -174,6 +174,8 @@ def parse_kasan(kasan_output: str) -> tuple[str, StackFrame | None, StackTrace, 
             else:
                 # got nothing, probably a functionname?
                 _, _, funcname = info_line.partition("BUG: KFENCE: ")
+            funcname = funcname.strip() if funcname is not None else None
+            bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
             return StackFrame(
                 funcname=funcname,
                 filename=filename,
@@ -224,6 +226,8 @@ def parse_kfence(kfence_output: str) -> tuple[str, StackFrame | None, StackTrace
             else:
                 # got nothing, probably a functionname?
                 _, _, funcname = info_line.partition("BUG: KFENCE: ")
+            funcname = funcname.strip() if funcname is not None else None
+            bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
             return StackFrame(
                 funcname=funcname,
                 filename=filename,
@@ -268,15 +272,15 @@ def parse_memsan(memsan_output: str) -> tuple[str, StackFrame | None, StackTrace
     Returns the extra bug info, frame describing location error triggered, and call trace
     and allocated trace as available.
     """
-    find_extra_info = partial(easy_match_extra_info, "WARNING: Memory Sanitizer: ")
-    find_triggering_loc = partial(easy_find_loc, "SUMMARY: AddressSanitizer: ")
+    find_extra_info = partial(easy_match_extra_info, "WARNING: MemorySanitizer: ")
+    find_triggering_loc = partial(easy_find_loc, "SUMMARY: MemorySanitizer: ")
 
     return parse_report_generic(
         memsan_output,
         find_extra_info,
         find_triggering_loc,
         parse_stack_frame_simple,
-        "WARNING: Memory Sanitizer: ",
+        "WARNING: MemorySanitizer: ",
         "value was created by",
     )
 
@@ -299,15 +303,16 @@ def _extract_location_ubsan(line: str) -> tuple[str, int | None, int | None]:
             line, _, offsetstr = linenostr.partition(" ")
 
     try:
-        lineno = int(line)
+        lineno = int(line.strip())
     except ValueError:
         lineno = None
     try:
         if " " in offsetstr:
             offsetstr, _, _ = offsetstr.partition(" ")
-        offset = int(offsetstr)
+        offset = int(offsetstr.strip())
     except ValueError:
         offset = None
+    filename = filename.strip() if filename is not None else None
     return filename, lineno, offset
 
 
@@ -318,6 +323,7 @@ def parse_ubsan(ubsan_output: str) -> tuple[str, StackFrame | None, StackTrace, 
     """
     # runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
     # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior file.cpp:7:21
+    # TODO: ultimately, can parse allocation stacks, but not using them yet.
 
     filename: str | None = None
     lineno: int | None = None
@@ -338,6 +344,7 @@ def parse_ubsan(ubsan_output: str) -> tuple[str, StackFrame | None, StackTrace, 
             filename, lineno, offset = _extract_location_ubsan(location)
         if "runtime error:" in stripped:
             _, _, extra_information = stripped.partition("error: ")
+    funcname = funcname.strip() if funcname is not None else None
     frame = StackFrame(
         funcname=funcname,
         filename=filename,
@@ -353,6 +360,7 @@ def parse_java_stack_trace(line: str) -> StackFrame:
     funcname = None
     filename = None
     lineno = None
+    lineno_int = None
     if "(" in line:
         funcname, _, filenamepart = line.partition("(")
         if filenamepart.endswith(")"):
@@ -361,7 +369,13 @@ def parse_java_stack_trace(line: str) -> StackFrame:
             filename, _, lineno = filenamepart.partition(":")
     else:
         funcname = line
-    lineno_int = int(lineno) if lineno is not None else None
+    try:
+        lineno_int = int(lineno.strip()) if lineno is not None else None
+    except ValueError:
+        lineno = None
+
+    funcname = funcname.strip() if funcname is not None else None
+    filename = filename.strip() if filename is not None else None
     return StackFrame(
         funcname=funcname,
         filename=filename,

--- a/src/repairchain/models/sanitizer_report.py
+++ b/src/repairchain/models/sanitizer_report.py
@@ -84,6 +84,10 @@ def easy_find_loc(find_triggered_loc: str, line: str) -> StackFrame | None:
             filename, lineno, offset = extract_location_symbolized(loc_str)
         elif "+" in loc_str:
             funcname, bytes_offset = extract_location_not_symbolized(loc_str)
+        filename = filename.strip() if filename is not None else None
+        funcname = funcname.strip() if funcname is not None else None
+        bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
+
         return StackFrame(
             funcname=funcname,
             filename=filename,
@@ -174,6 +178,7 @@ def parse_kasan(kasan_output: str) -> tuple[str, StackFrame | None, StackTrace, 
             else:
                 # got nothing, probably a functionname?
                 _, _, funcname = info_line.partition("BUG: KFENCE: ")
+            filename = filename.strip() if filename is not None else None
             funcname = funcname.strip() if funcname is not None else None
             bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
             return StackFrame(
@@ -226,6 +231,7 @@ def parse_kfence(kfence_output: str) -> tuple[str, StackFrame | None, StackTrace
             else:
                 # got nothing, probably a functionname?
                 _, _, funcname = info_line.partition("BUG: KFENCE: ")
+            filename = filename.strip() if filename is not None else None
             funcname = funcname.strip() if funcname is not None else None
             bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
             return StackFrame(
@@ -345,6 +351,7 @@ def parse_ubsan(ubsan_output: str) -> tuple[str, StackFrame | None, StackTrace, 
         if "runtime error:" in stripped:
             _, _, extra_information = stripped.partition("error: ")
     funcname = funcname.strip() if funcname is not None else None
+    filename = filename.strip() if filename is not None else None
     frame = StackFrame(
         funcname=funcname,
         filename=filename,

--- a/src/repairchain/models/stack_trace.py
+++ b/src/repairchain/models/stack_trace.py
@@ -131,12 +131,18 @@ def extract_location_symbolized(line: str) -> tuple[str, int | None, int | None]
         offset = int(offsetstr.strip())
     except ValueError:
         offset = None
-    filename = filename.strip() if filename is not None else None
+
+    filename = filename.strip()
 
     return filename, lineno, offset
 
 
 def extract_stack_frame_from_line_symbolized(line: str) -> StackFrame:
+    funcname: str | None = None
+    lineno: int | None = None
+    offset: int | None = None
+    filename = line
+
     _, _, restline = line.partition(" in ")
     if ")" in restline:
         funcname, _, restline = restline.partition("(")
@@ -145,6 +151,8 @@ def extract_stack_frame_from_line_symbolized(line: str) -> StackFrame:
         funcname, _, restline = restline.partition(" ")
 
     filename, lineno, offset = extract_location_symbolized(restline)
+    filename = filename.strip()
+    funcname = funcname.strip() if funcname is not None else funcname
 
     return StackFrame(
         funcname=funcname,
@@ -155,12 +163,19 @@ def extract_stack_frame_from_line_symbolized(line: str) -> StackFrame:
     )
 
 
-def extract_location_not_symbolized(line: str) -> tuple[str, str | None]:
-    # should return function name, byte offset
-    raise NotImplementedError
-
-
 def extract_stack_frame_from_line_not_symbolized(line: str) -> StackFrame:
+    funcname, bytes_offset = extract_location_not_symbolized(line)
+    funcname = funcname.strip() if funcname is not None else None
+    bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
+    return StackFrame(
+        funcname=funcname,
+        filename=None,
+        lineno=None,
+        offset=None,
+        bytes_offset=bytes_offset)
+
+
+def extract_location_not_symbolized(line: str) -> tuple[str | None, str | None]:
     funcname: str | None = None
     bytes_offset: str | None = None
 
@@ -173,10 +188,4 @@ def extract_stack_frame_from_line_not_symbolized(line: str) -> StackFrame:
         funcname, _, bytes_offset = line.partition("+")
     funcname = funcname.strip() if funcname is not None else None
     bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
-
-    return StackFrame(
-        funcname=funcname,
-        filename=None,
-        lineno=None,
-        offset=None,
-        bytes_offset=bytes_offset)
+    return funcname, bytes_offset

--- a/src/repairchain/models/stack_trace.py
+++ b/src/repairchain/models/stack_trace.py
@@ -121,16 +121,18 @@ def extract_location_symbolized(line: str) -> tuple[str, int | None, int | None]
         if ":" in linenostr:
             line, _, offsetstr = linenostr.partition(":")
     try:
-        lineno = int(line)
+        lineno = int(line.strip())
     except ValueError:
         lineno = None
 
     try:
         if " " in offsetstr:
             offsetstr, _, _ = offsetstr.partition(" ")
-        offset = int(offsetstr)
+        offset = int(offsetstr.strip())
     except ValueError:
         offset = None
+    filename = filename.strip() if filename is not None else None
+
     return filename, lineno, offset
 
 
@@ -169,6 +171,8 @@ def extract_stack_frame_from_line_not_symbolized(line: str) -> StackFrame:
     line = line.lstrip()
     if "+" in line:
         funcname, _, bytes_offset = line.partition("+")
+    funcname = funcname.strip() if funcname is not None else None
+    bytes_offset = bytes_offset.strip() if bytes_offset is not None else None
 
     return StackFrame(
         funcname=funcname,

--- a/src/repairchain/strategies/generation/llm/helper_code.py
+++ b/src/repairchain/strategies/generation/llm/helper_code.py
@@ -44,10 +44,12 @@ There must be {number_patches} children, each corresponding to a modified line.
 """
 
 CONTEXT_UNINIT_MEMORY = """
-The following code has a security vulnerability related to uninitialized memory access:
+The following function has a vulnerability related to uninitialized memory access:
 {code}
-The following line has an issue with accessing uninitialized memory:
-{line}
+The line with the uninitialized memory access vulnerability is:
+{error_line}
+The unitialized memory is allocated here:
+{alloc_line}
 <instructions>
 Fix the code by creating a new line of code that initializes the uninitialized memory.
 Create a JSON object with the new line of code.
@@ -255,10 +257,15 @@ class CodeHelper:
         )
         return self._help_with_template(user_prompt)
 
-    def help_with_memory_initialization(self, code: str, line: str, num_patches: int) -> Code | None:
+    def help_with_memory_initialization(self,
+                                        code: str,
+                                        error_line: str,
+                                        alloc_line: str,
+                                        num_patches: int) -> Code | None:
         user_prompt = CONTEXT_UNINIT_MEMORY.format(
             code=code,
-            line=line,
+            error_line=error_line,
+            alloc_line=alloc_line,
             number_patches=num_patches,
         )
         return self._help_with_template(user_prompt)


### PR DESCRIPTION
Note that I have already pulled in the changes from https://github.com/ChrisTimperley/RepairChain/pull/72 on this branch, my idea being you can tell me to only merge that one, or accept this one.  Those changes should be accepted regardless.

This PR improves initialize memory template strategy to take better advantage of the more detailed information in the sanitizer report.

Thus, the relevant changes are to llm/helper_code.py, and to init_mem.py

Rationale: The original initialize memory template was a bit naive/conservative.  It only tried to repair one location --- where the error triggered --- which isn't always even in the implicated function, but rather can be buried several calls deep.

This version instead attempts patches to initialize the uninitialized memory along calls in the allocation stack for the sanitizer report.

I have "tested" it by modifying the sanitizer.txt for nginx to be a fake memsan report --- corresponding to the gpt produced report, but with stack frames referencing nginx locations.  It does happily produce potential patches, at least when GPT responds.  

I can't test it properly since AFAIK we don't have any memory sanitizer reports for uninitialized memory errors. 